### PR TITLE
fix: corrected version typo

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -4,5 +4,5 @@
     "name": "steam-taskbar-progress",
     "common_name": "Taskbar Download progress",
     "description": "Display the Steam download status on the Windows taskbar",
-    "versionj": "1.1.0"
+    "version": "1.1.0"
 }


### PR DESCRIPTION
This resolves the version number not being displayed on Millennium's plugin menu.
This is also present in your [librarian plugin](https://github.com/luthor112/steam-librarian/blob/dbf2dee8cdf616b06af56dd8e0388b1f9fee5556/plugin.json#L7).