### PR TITLE
Fixed documented config file location in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Millennium plugin that displays the Steam download status on the Windows taskb
     - Right click the download indicator to use
 
 ## Configuration
-- `<STEAM>\plugins\steam-librarian\config.json`
+- `<STEAM>\plugins\steam-taskbar-progress\config.json`
 
 ## Prerequisites
 - [Millennium](https://steambrew.app/)


### PR DESCRIPTION
I noticed on steambrew.app that the documented config file location wasn't correct so i checked here and saw the same some I'm just making this PR to fix it.